### PR TITLE
Missing Parenthesis Causing Incorrect delay and TTL being set in DbalProducer send()

### DIFF
--- a/DbalProducer.php
+++ b/DbalProducer.php
@@ -95,7 +95,7 @@ class DbalProducer implements Producer
                 throw new \LogicException(sprintf('Delay must be positive integer but got: "%s"', $delay));
             }
 
-            $dbalMessage['delayed_until'] = time() + (int) $delay / 1000;
+            $dbalMessage['delayed_until'] = time() + ((int) $delay / 1000);
         }
 
         $timeToLive = $message->getTimeToLive();
@@ -111,7 +111,7 @@ class DbalProducer implements Producer
                 throw new \LogicException(sprintf('TimeToLive must be positive integer but got: "%s"', $timeToLive));
             }
 
-            $dbalMessage['time_to_live'] = time() + (int) $timeToLive / 1000;
+            $dbalMessage['time_to_live'] = time() + ((int) $timeToLive / 1000);
         }
 
         try {


### PR DESCRIPTION
Added missing parentheses where delay and TTL are being set inside of send(). Before this fix, they were returning the incorrect value, and one that is usually a float, not an int, thus throwing an SQL type mismatch error.